### PR TITLE
Hotfix for issue #11 for undefined 'require()'

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,14 @@ let win
 
 function createWindow () {
     // Create the browser window.
-    win = new BrowserWindow({width: 800, height: 600, icon: path.join(__dirname, 'images/icons/png/icon_32x32@2x.png')})
+    win = new BrowserWindow({
+        webPreferences: {
+            nodeIntegration: true
+        },
+        width: 800,
+        height: 600,
+        icon: path.join(__dirname, 'images/icons/png/icon_32x32@2x.png')
+    })
 
     win.maximize()
     


### PR DESCRIPTION
An incompatibility with the newer versions os
electron emerged, since the default value os the
variable 'nodeIntegration' was changed to false,
causing problems with the function 'require()'
which is found on the server side node.

The issue was solved by explicitly definint the
variable to 'true' in main.js