### PR TITLE
Fix for "invalid version" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "name"    : "DICe",
-    "version" : "2.0",
+    "version" : "2.0.0",
     "main"    : "main.js"
 }


### PR DESCRIPTION
One extra version layer was added in package.json to silence the npm warning during install 
```
npm WARN Invalid version: "2.0"

```