### PR TITLE
Update to check for location of binaries.

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -20,8 +20,7 @@ if(os.platform()=='win32'){
     setExecPaths(win_path);
 }else if(os.platform()=='linux'){
     setExecPaths(linux_path);
-}
-else if(os.platform()=='darwin'){
+}else if(os.platform()=='darwin'){
     setExecPaths(darwin_path);
 }
 // the exec paths above can be overridden by setting a execPathOverride
@@ -108,12 +107,12 @@ function setExecPaths(path){
     execOpenCVServerPath = path + 'DICe_OpenCVServer.exe';
     execTrackingMoviePath = path + 'DICe_TrackingMovieMaker.exe';
   }else if(os.platform()=='linux' || os.platform()=='darwin'){
-    execPath = path+'dice';
-    execCrossInitPath = path+'DICe_CrossInit';
-    execCineStatPath = path+'DICe_CineStat';
-    execCineToTiffPath = path+'DICe_CineToTiff';
-    execCalPath = path+'DICe_Cal';
-    execOpenCVServerPath = path+'DICe_OpenCVServer';
-    execTrackingMoviePath = path+'DICe_TrackingMovieMaker';
+    execPath = path + 'dice';
+    execCrossInitPath = path + 'DICe_CrossInit';
+    execCineStatPath = path + 'DICe_CineStat';
+    execCineToTiffPath = path + 'DICe_CineToTiff';
+    execCalPath = path + 'DICe_Cal';
+    execOpenCVServerPath = path + 'DICe_OpenCVServer';
+    execTrackingMoviePath = path + 'DICe_TrackingMovieMaker';    
   }
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -171,34 +171,56 @@ function createHiddenDir(){
     });
 }
 
-function testForDebugMsg(){
-    // test if debugging messages are turned on or off
-    child_process = require('child_process');
-    proc = child_process.execFile(execPath,['-d'],{cwd:workingDirectory});
-    proc.on('error', function(){
-        alert('Error! invalid DICe executable: ' + execPath);
-    });
-    proc.on('close', (code) => {
-        console.log(`DICe test for debug messages exited with code ${code}`);
-        if(code==0){
-            console.log("debug messages are on");
-            diceDebugMsgOn = true;
-        }
-    });
-    // test if the tracking library is available
-    proc = child_process.execFile(execPath,['--tracklib'],{cwd:workingDirectory});
-    proc.on('error', function(){
-        alert('Error! invalid DICe executable: ' + execPath);
-    });
-    proc.on('close', (code) => {
-        console.log(`DICe test for tracklib exited with code ${code}`);
-        if(code==0){
-            console.log("tracklib is on");
-            diceTrackLibOn = true;
-            if(showStereoPaneState==1&&$("#analysisModeSelect").val()=='tracking'){
-                $(".non-tracklib-tools").hide();
-                $(".tracklib-tools").show();
-            }
+function testForDebugMsg() {
+    // test if the dice exectuable path exists
+    exec_check = require('fs');
+    exec_check.access(execPath, (err) => {
+        if (err) {
+            alert("DICe executable path does not exist. Did you set the path in global.js?\nPlease select the correct path in the following dialog.");
+            dialog.showOpenDialog({
+                properties: ['openDirectory']
+            }, function (folder) {
+                if (folder != 'undefined'){
+                    if(os.platform()=='win32'){
+                        folder = folder +"\\";
+                    }else if(os.platform()=='linux' || os.platform()=='darwin'){
+                        folder = folder +"/";
+                    }
+                    execPathOverride = folder;
+                    alert('setting the exec path to: ' + execPathOverride);
+                    setExecPaths(execPathOverride);
+                }
+            });
+        } else {
+            // test if debugging messages are turned on or off
+            child_process = require('child_process');
+            proc = child_process.execFile(execPath, ['-d'], { cwd: workingDirectory });
+            proc.on('error', function () {
+                alert('Error! invalid DICe executable: ' + execPath);
+            });
+            proc.on('close', (code) => {
+                console.log(`DICe test for debug messages exited with code ${code}`);
+                if (code == 0) {
+                    console.log("debug messages are on");
+                    diceDebugMsgOn = true;
+                }
+            });
+            // test if the tracking library is available
+            proc = child_process.execFile(execPath, ['--tracklib'], { cwd: workingDirectory });
+            proc.on('error', function () {
+                alert('Error! invalid DICe executable: ' + execPath);
+            });
+            proc.on('close', (code) => {
+                console.log(`DICe test for tracklib exited with code ${code}`);
+                if (code == 0) {
+                    console.log("tracklib is on");
+                    diceTrackLibOn = true;
+                    if (showStereoPaneState == 1 && $("#analysisModeSelect").val() == 'tracking') {
+                        $(".non-tracklib-tools").hide();
+                        $(".tracklib-tools").show();
+                    }
+                }
+            });
         }
     });
 }


### PR DESCRIPTION
Update to test for executable and allow the user to choose the path to the binaries if the binaries do not exist.

Updates execPathOverride to allow this to be saved for future startups. If this path is then changed manually in `.dice.js` the test for executable will fail again and the process will start again.
There is a popup that still comes up when the execPathOverride is used (from elsewhere in the code) but I wasn't sure if it was a good idea to remove this.

This is in response to issue 160 in the dice [repo](https://github.com/dicengine/dice/issues/160).